### PR TITLE
Mermaid Renderer customization

### DIFF
--- a/src/9.0/Siren.Infrastructure.Rendering/AzureDevOpsRenderTemplate.cs
+++ b/src/9.0/Siren.Infrastructure.Rendering/AzureDevOpsRenderTemplate.cs
@@ -1,0 +1,11 @@
+using Siren.Interfaces;
+
+namespace Siren.Infrastructure.Rendering;
+
+public class AzureDevOpsRenderTemplate(IProgramArguments programArguments) : IRenderTemplate
+{
+    public bool IsApplicable() => programArguments.RenderTemplate.ToLower() == "azuredevops";
+    public string ThemeLine => null; 
+    public string MermaidBlockStart => ":::mermaid";
+    public string MermaidBlockEnd => ":::";
+}

--- a/src/9.0/Siren.Infrastructure.Rendering/DefaultRenderTemplate.cs
+++ b/src/9.0/Siren.Infrastructure.Rendering/DefaultRenderTemplate.cs
@@ -1,0 +1,11 @@
+using Siren.Interfaces;
+
+namespace Siren.Infrastructure.Rendering;
+
+public class DefaultRenderTemplate(IProgramArguments programArguments) : IRenderTemplate
+{
+    public bool IsApplicable() => programArguments.RenderTemplate.ToLower() == "default";
+    public string ThemeLine => "%%{init: {'theme':'neutral'}}%%";
+    public string MermaidBlockStart => "```mermaid";
+    public string MermaidBlockEnd => "```";
+}

--- a/src/9.0/Siren.Infrastructure.Rendering/IRenderTemplate.cs
+++ b/src/9.0/Siren.Infrastructure.Rendering/IRenderTemplate.cs
@@ -1,0 +1,9 @@
+namespace Siren.Infrastructure.Rendering;
+
+public interface IRenderTemplate
+{
+    bool IsApplicable();
+    string ThemeLine { get; }
+    string MermaidBlockStart { get; }
+    string MermaidBlockEnd { get; }
+}

--- a/src/9.0/Siren.Infrastructure.Rendering/MermaidConstants.cs
+++ b/src/9.0/Siren.Infrastructure.Rendering/MermaidConstants.cs
@@ -4,9 +4,6 @@ namespace Siren.Infrastructure.Rendering
     {
         public const string SirenAnchorStart = "<!--- SIREN_START -->";
         public const string SirenAnchorEnd = "<!--- SIREN_END -->";
-        public const string MermaidAnchorStart = "```mermaid";
-        public const string MermaidAnchorEnd = "```";
         public const string MermaidErDiagramHeader = "erDiagram";
-        public const string MermaidNeutralThemeLine = "%%{init: {'theme':'neutral'}}%%";
     }
 }

--- a/src/9.0/Siren.Infrastructure.Rendering/Siren.Infrastructure.Rendering.csproj
+++ b/src/9.0/Siren.Infrastructure.Rendering/Siren.Infrastructure.Rendering.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Siren.Domain\Siren.Domain.csproj" />
+    <ProjectReference Include="..\Siren.Interfaces\Siren.Interfaces.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />

--- a/src/9.0/Siren.Interfaces/IProgramArguments.cs
+++ b/src/9.0/Siren.Interfaces/IProgramArguments.cs
@@ -10,5 +10,6 @@ public interface IProgramArguments
     string ConnectionString { get; }
     string FilterEntities { get; }
     string SkipEntities { get; }
+    string RenderTemplate { get; }
     IEnumerable<IArgumentError> Initialize(string[] args);
 }

--- a/src/9.0/Siren.Tests.Unit/SirenApplicationTests.cs
+++ b/src/9.0/Siren.Tests.Unit/SirenApplicationTests.cs
@@ -4,6 +4,7 @@ using Siren.Application;
 using Siren.Infrastructure.Io;
 using Siren.Infrastructure.Rendering;
 using Siren.Interfaces;
+using Siren.Tool;
 using Xunit;
 
 namespace Siren.Tests.Unit
@@ -57,7 +58,7 @@ namespace Siren.Tests.Unit
                 var domainRenderer = Substitute.For<IDomainRenderer>();
                 var fileWriter = Substitute.For<IFileWriter>();
                 var logger = Substitute.For<ILogger<SirenApplication>>();
-                var programArguments = Substitute.For<IProgramArguments>();
+                var programArguments = new ProgramArguments();
 
                 universeLoader.IsApplicable().ReturnsForAnyArgs(true);
 

--- a/src/9.0/Siren.Tool/ProgramArguments.cs
+++ b/src/9.0/Siren.Tool/ProgramArguments.cs
@@ -28,6 +28,9 @@ namespace Siren.Tool
         [Option('s', "skipEntities", Required = false, HelpText = "Comma-separated list of entities to skip.")]
         public string SkipEntities { get; set; }
 
+        [Option('t', "template", Required = false, HelpText = "Render template (e.g. AzureDevOps). Default is 'default'.", Default = "default")]
+        public string RenderTemplate { get; set; }
+
         public IEnumerable<IArgumentError> Initialize(string[] args)
         {
             var parsedArguments = Parser.Default.ParseArguments<ProgramArguments>(args);
@@ -40,6 +43,7 @@ namespace Siren.Tool
                 ConnectionString = arguments.ConnectionString;
                 FilterEntities = arguments.FilterEntities;
                 SkipEntities = arguments.SkipEntities;
+                RenderTemplate = arguments.RenderTemplate;
             }
 
             return parsedArguments.Errors.Select(error =>
@@ -52,8 +56,9 @@ namespace Siren.Tool
                    + $"OutputFilePath: '{OutputFilePath}'\r\n"
                    + $"MarkdownAnchor: '{MarkdownAnchor}'\r\n"
                    + $"ConnectionString: '{ConnectionString}'\r\n"
+                   + $"FilterEntities: '{FilterEntities}'\r\n"
                    + $"SkipEntities: '{SkipEntities}'\r\n"
-                   + $"FilterEntities: '{FilterEntities}'\r\n";
+                   + $"RenderTemplate: '{RenderTemplate}'\r\n";
         }
     }
 

--- a/src/9.0/Siren.Tool/Startup.cs
+++ b/src/9.0/Siren.Tool/Startup.cs
@@ -34,7 +34,9 @@ namespace Siren.Tool
                 .AddSingleton<IKeyBuilder, KeyBuilder>()
                 .AddSingleton<IRelationshipFilter, RelationshipFilter>()
                 .AddSingleton<ISearchApplication, SearchApplication>()
-                .AddSingleton<IDomainRenderer, MermaidRenderer>();
+                .AddSingleton<IDomainRenderer, MermaidRenderer>()
+                .AddSingleton<IRenderTemplate, AzureDevOpsRenderTemplate>()
+                .AddSingleton<IRenderTemplate, DefaultRenderTemplate>();
 
             services.AddLogging(o => o.AddConsole());
 


### PR DESCRIPTION
Add option `template` with value 'AzureDevOps' or 'default'. If 'AzureDevOps' is specified, it renders ` :::mermaid ` block; otherwise it renders ` ```mermaid ` block with 'neutral' theme line.

Closes #13 